### PR TITLE
add a better config for dqn_cartpole

### DIFF
--- a/configs/dqn_cartpole_1.json
+++ b/configs/dqn_cartpole_1.json
@@ -1,0 +1,57 @@
+{
+    "type": "dqn_agent",
+    "max_timesteps": 1e5,
+    "max_episode_timesteps": 200,
+
+    "batch_size": 128,
+    "batched_observe": 1,
+
+    "memory": {
+        "type": "replay",
+        "capacity": 50000,
+        "random_sampling": true
+    },
+
+    "optimizer": {
+        "type": "clipped_step",
+        "clipping_value": 0.005,
+        "optimizer": {
+            "type": "adam",
+            "learning_rate": 5e-4
+        }
+    },
+
+    "discount": 0.99,
+
+    "variable_noise": null,
+
+    "first_update": 1000,
+    "update_frequency": 1,
+    "repeat_update": 1,
+
+    "target_sync_frequency": 500,
+    "target_update_weight": 1.0,
+
+    "double_q_model": true,
+
+    "explorations_spec": {
+        "type": "epsilon_anneal",
+        "initial_epsilon": 0.8,
+        "final_epsilon": 0.01,
+        "timesteps": 1e4
+    },
+
+    "network": [
+        {
+            "type": "dense",
+            "size": 64,
+            "activation": "relu"
+        },
+
+        {
+            "type": "dense",
+            "size": 32,
+            "activation": "relu"
+        }
+    ]
+}


### PR DESCRIPTION
I've added a better config file (dqn_cartpole_1.json) for DQN on CartPole-v0, compared to the provided config file dqn_cartpole.json.

_performance of new cofig dqn_cartpole_1.json:_
![result](https://user-images.githubusercontent.com/23320220/34107982-887d254a-e3fe-11e7-9654-cecbeaff0fd8.png)
_performance of config dqn_cartpole.json:_
![result1](https://user-images.githubusercontent.com/23320220/34108029-c0880824-e3fe-11e7-9126-16ea1eba8d52.png)
